### PR TITLE
Logging for library usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__
+.pytest_cache/
+*.egg-info/
+build/
+dist/

--- a/pyjfuzz/core/pjf_grammar.py
+++ b/pyjfuzz/core/pjf_grammar.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from gramfuzz import GramFuzzer
+from gramfuzz import *
 import json
 
 def generate_json(path):

--- a/pyjfuzz/core/pjf_logger.py
+++ b/pyjfuzz/core/pjf_logger.py
@@ -28,8 +28,10 @@ class PJFLogger(object):
 
     @staticmethod
     def init_logger():
-        logging.basicConfig(filename="pjf_{0}.log".format(time.strftime("%d_%m_%Y")), level=PYJFUZZ_LOGLEVEL)
         logger = logging.getLogger(__name__)
+        logger.setLevel(level=PYJFUZZ_LOGLEVEL)
+        filehandler = logging.FileHandler("pjf_{0}.log".format(time.strftime("%d_%m_%Y")))
+        logger.addHandler(filehandler)
         sys.tracebacklimit = 10
 
         def handle_exception(exc_type, exc_value, exc_traceback):


### PR DESCRIPTION
The changes in Commit b230323  allow logging to different files when using PyJFuzz as a library. Previously, all logging from a project that uses this library went into pjf_*.log, it was neither possible to control the log file path nor to add separate loggers. The changes should not affect the current  functionality.
Executing the tests was not possible without changing the GramFuzzer import (Commit 
4a87ca5). Additionally, I added a basic .gitignore to exclude files that are automatically added when executing tests etc.