### PR TITLE
Fixed fuzzing with parameters in case of lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.egg-info/
 build/
 dist/
+*.pyc

--- a/pyjfuzz/core/pjf_factory.py
+++ b/pyjfuzz/core/pjf_factory.py
@@ -160,7 +160,10 @@ class PJFFactory(object):
                     elif type(key) == list:
                         arr.append(self.fuzz_elements(key))
                     else:
-                        arr.append(self.mutator.fuzz(key))
+                        if len(self.config.parameters) <= 0:
+                            arr.append(self.mutator.fuzz(key))
+                        else:
+                            arr.append(key)
                 element = arr
                 del arr
         except Exception as e:

--- a/pyjfuzz/core/pjf_factory.py
+++ b/pyjfuzz/core/pjf_factory.py
@@ -153,17 +153,16 @@ class PJFFactory(object):
                 element = tmp_element
                 del tmp_element
             elif type(element) == list:
-                if len(self.config.parameters) <= 0:
-                    arr = []
-                    for key in element:
-                        if type(key) == dict:
-                            arr.append(self.fuzz_elements(key))
-                        elif type(key) == list:
-                            arr.append(self.fuzz_elements(key))
-                        else:
-                            arr.append(self.mutator.fuzz(key))
-                    element = arr
-                    del arr
+                arr = []
+                for key in element:
+                    if type(key) == dict:
+                        arr.append(self.fuzz_elements(key))
+                    elif type(key) == list:
+                        arr.append(self.fuzz_elements(key))
+                    else:
+                        arr.append(self.mutator.fuzz(key))
+                element = arr
+                del arr
         except Exception as e:
             raise PJFBaseException(e.message if hasattr(e, "message") else str(e))
         return element

--- a/test/test_pjf_factory.py
+++ b/test/test_pjf_factory.py
@@ -71,6 +71,12 @@ class TestPJFFactory(unittest.TestCase):
                                                      indent=True, nologo=True)))
         self.assertTrue(json.fuzzed)
 
+    def test_object_parameters(self):
+        json = PJFFactory(PJFConfiguration(Namespace(parameters="d", json={"a": [{"b" : "c"}, "abcd"]}, nologo=True, level=6)))
+        self.assertTrue(json != json.fuzzed)
+        self.assertTrue("abcd" in json.fuzzed)
+
+
 
 def test():
     print("=" * len(__TITLE__))


### PR DESCRIPTION
This pull request is a fix for fuzzing with / without parameters.

Currently, fuzzing with parameters is only possible when the parameters are keys inside dicts. This works recursive for dicts of dicts as expected. However, as soon as a parameter is a key inside a dict element in a list, it does not get fuzzed.

Example for successful fuzzing with parameters (only the value of "d" gets fuzzed):

```
from pyjfuzz.lib import PJFConfiguration, PJFFactory
from argparse import Namespace
input_dict = { "a" : "b", "c" : { "d" : "e"}}
fuzzer = PJFFactory(PJFConfiguration(Namespace(json=input_dict, nologo=True, level=6, parameters="d")))
```

Failing example (nothing at all gets fuzzed):

```
from pyjfuzz.lib import PJFConfiguration, PJFFactory
from argparse import Namespace
input_dict ={ "a" : "b", "c" : [ {"d" : "e"}, {"f" : "g"}]}
fuzzer = PJFFactory(PJFConfiguration(Namespace(json=input_dict, nologo=True, level=6, parameters="d")))
```

The fix seems to be to simply remove an if statement, see diff. It does not influence any of the tests (some of them are failing out of other reasons, I will submit another pull requests for them).