### PR TITLE
Fix fuzzing with parameters in case of lists (Part 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.egg-info/
 build/
 dist/
+*.pyc

--- a/pyjfuzz/core/pjf_factory.py
+++ b/pyjfuzz/core/pjf_factory.py
@@ -160,7 +160,10 @@ class PJFFactory(object):
                     elif type(key) == list:
                         arr.append(self.fuzz_elements(key))
                     else:
-                        arr.append(self.mutator.fuzz(key))
+                        if len(self.config.parameters) <= 0:
+                            arr.append(self.mutator.fuzz(key))
+                        else:
+                            arr.append(key)
                 element = arr
                 del arr
         except Exception as e:

--- a/test/test_pjf_factory.py
+++ b/test/test_pjf_factory.py
@@ -71,6 +71,12 @@ class TestPJFFactory(unittest.TestCase):
                                                      indent=True, nologo=True)))
         self.assertTrue(json.fuzzed)
 
+    def test_object_parameters(self):
+        json = PJFFactory(PJFConfiguration(Namespace(parameters="d", json={"a": [{"b" : "c"}, "abcd"]}, nologo=True, level=6)))
+        self.assertTrue(json != json.fuzzed)
+        self.assertTrue("abcd" in json.fuzzed)
+
+
 
 def test():
     print("=" * len(__TITLE__))


### PR DESCRIPTION
This pull request ensures that list items that are neither dicts nor lists are not fuzzed when fuzzing with parameters. I also added a testcase to check the correct behaviour.